### PR TITLE
OAK-9133: low latency updates with RT support

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexWriterFactory.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexWriterFactory.java
@@ -22,9 +22,11 @@ package org.apache.jackrabbit.oak.plugins.index.lucene;
 import org.apache.jackrabbit.oak.plugins.index.lucene.writer.LuceneIndexWriter;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriterFactory;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.lucene.index.IndexableField;
 
-public interface LuceneIndexWriterFactory extends FulltextIndexWriterFactory {
+public interface LuceneIndexWriterFactory extends FulltextIndexWriterFactory<Iterable<? extends IndexableField>> {
     @Override
-    LuceneIndexWriter newInstance(IndexDefinition definition, NodeBuilder definitionBuilder, boolean reindex);
+    LuceneIndexWriter newInstance(IndexDefinition definition, NodeBuilder definitionBuilder, CommitInfo commitInfo, boolean reindex);
 }

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/LocalIndexWriterFactory.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/LocalIndexWriterFactory.java
@@ -24,10 +24,11 @@ import java.io.IOException;
 import org.apache.jackrabbit.oak.plugins.index.lucene.writer.LuceneIndexWriter;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriterFactory;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.lucene.index.IndexableField;
 
-public class LocalIndexWriterFactory implements FulltextIndexWriterFactory {
+public class LocalIndexWriterFactory implements FulltextIndexWriterFactory<Iterable<? extends IndexableField>> {
     private final LuceneDocumentHolder documentHolder;
     private final String indexPath;
 
@@ -37,7 +38,8 @@ public class LocalIndexWriterFactory implements FulltextIndexWriterFactory {
     }
 
     @Override
-    public LuceneIndexWriter newInstance(IndexDefinition definition, NodeBuilder definitionBuilder, boolean reindex) {
+    public LuceneIndexWriter newInstance(IndexDefinition definition, NodeBuilder definitionBuilder,
+                                         CommitInfo commitInfo, boolean reindex) {
         return new LocalIndexWriter(definition);
     }
 

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/DefaultIndexWriterFactory.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/DefaultIndexWriterFactory.java
@@ -26,6 +26,7 @@ import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexWriterFactory;
 import org.apache.jackrabbit.oak.plugins.index.lucene.directory.DirectoryFactory;
 import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 
@@ -44,8 +45,8 @@ public class DefaultIndexWriterFactory implements LuceneIndexWriterFactory {
     }
 
     @Override
-    public LuceneIndexWriter newInstance(IndexDefinition def,
-                                         NodeBuilder definitionBuilder, boolean reindex) {
+    public LuceneIndexWriter newInstance(IndexDefinition def, NodeBuilder definitionBuilder,
+                                         CommitInfo commitInfo, boolean reindex) {
         Preconditions.checkArgument(def instanceof LuceneIndexDefinition,
                 "Expected {} but found {} for index definition",
                 LuceneIndexDefinition.class, def.getClass());

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexEditor2Test.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexEditor2Test.java
@@ -281,10 +281,10 @@ public class LuceneIndexEditor2Test {
     }
 
 
-    private class TestWriterFactory implements FulltextIndexWriterFactory {
+    private class TestWriterFactory implements FulltextIndexWriterFactory<Iterable<? extends IndexableField>> {
         @Override
-        public LuceneIndexWriter newInstance(IndexDefinition definition,
-                                             NodeBuilder definitionBuilder, boolean reindex) {
+        public LuceneIndexWriter newInstance(IndexDefinition definition, NodeBuilder definitionBuilder,
+                                             CommitInfo commitInfo, boolean reindex) {
             return writer;
         }
     }

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/MultiplexingLucenePropertyIndexTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/MultiplexingLucenePropertyIndexTest.java
@@ -95,11 +95,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static com.google.common.collect.ImmutableList.of;
-import static org.apache.jackrabbit.oak.plugins.memory.PropertyStates.createProperty;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class MultiplexingLucenePropertyIndexTest extends AbstractQueryTest {
     private ExecutorService executorService = Executors.newFixedThreadPool(2);
@@ -153,7 +149,7 @@ public class MultiplexingLucenePropertyIndexTest extends AbstractQueryTest {
         DefaultIndexWriterFactory factory = new DefaultIndexWriterFactory(mip,
                 new DefaultDirectoryFactory(null, null),
                 new LuceneIndexWriterConfig());
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
         writer.close(0);
 
         //2. Construct the readers
@@ -174,7 +170,7 @@ public class MultiplexingLucenePropertyIndexTest extends AbstractQueryTest {
         //1. Have 2 reader created by writes in 2 diff mounts
         DirectoryFactory directoryFactory = new DefaultDirectoryFactory(null, null);
         DefaultIndexWriterFactory factory = new DefaultIndexWriterFactory(mip, directoryFactory, new LuceneIndexWriterConfig());
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
 
         Document doc = newDoc("/content/en");
         doc.add(new StringField("foo", "bar", Field.Store.NO));

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/reader/DefaultIndexReaderFactoryTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/reader/DefaultIndexReaderFactoryTest.java
@@ -35,14 +35,12 @@ import org.apache.jackrabbit.oak.plugins.index.lucene.writer.DefaultIndexWriterF
 import org.apache.jackrabbit.oak.plugins.index.lucene.writer.LuceneIndexWriter;
 import org.apache.jackrabbit.oak.plugins.index.lucene.writer.LuceneIndexWriterConfig;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
-import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
 import org.apache.jackrabbit.oak.spi.mount.Mounts;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.StringField;
-import org.apache.lucene.index.IndexReader;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -73,7 +71,7 @@ public class DefaultIndexReaderFactoryTest {
     @Test
     public void indexDir() throws Exception{
         LuceneIndexWriterFactory factory = newDirectoryFactory();
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
 
         writer.updateDocument("/content/en", newDoc("/content/en"));
         writer.close(0);
@@ -90,12 +88,7 @@ public class DefaultIndexReaderFactoryTest {
         assertEquals(1, reader.getReader().numDocs());
 
         final AtomicBoolean closed = new AtomicBoolean();
-        reader.getReader().addReaderClosedListener(new IndexReader.ReaderClosedListener() {
-            @Override
-            public void onClose(IndexReader reader) {
-                closed.set(true);
-            }
-        });
+        reader.getReader().addReaderClosedListener(reader1 -> closed.set(true));
 
         reader.close();
 
@@ -111,7 +104,7 @@ public class DefaultIndexReaderFactoryTest {
 
         DirectoryFactory directoryFactory = new DefaultDirectoryFactory(null, new DataStoreBlobStore(ds));
         LuceneIndexWriterFactory factory = new DefaultIndexWriterFactory(mip, directoryFactory, writerConfig);
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
 
         writer.updateDocument("/content/en", newDoc("/content/en"));
         writer.close(0);
@@ -128,12 +121,7 @@ public class DefaultIndexReaderFactoryTest {
         assertEquals(1, reader.getReader().numDocs());
 
         final AtomicBoolean closed = new AtomicBoolean();
-        reader.getReader().addReaderClosedListener(new IndexReader.ReaderClosedListener() {
-            @Override
-            public void onClose(IndexReader reader) {
-                closed.set(true);
-            }
-        });
+        reader.getReader().addReaderClosedListener(reader1 -> closed.set(true));
 
         reader.close();
 
@@ -145,7 +133,7 @@ public class DefaultIndexReaderFactoryTest {
         LuceneIndexWriterFactory factory = newDirectoryFactory();
         enabledSuggestorForSomeProp();
         defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
 
         Document doc = newDoc("/content/en");
         doc.add(new StringField(FieldNames.SUGGEST, "test", null));
@@ -163,7 +151,7 @@ public class DefaultIndexReaderFactoryTest {
     @Test
     public void multipleReaders() throws Exception{
         LuceneIndexWriterFactory factory = newDirectoryFactory();
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
 
         writer.updateDocument("/content/en", newDoc("/content/en"));
         writer.updateDocument("/libs/config", newDoc("/libs/config"));
@@ -179,7 +167,7 @@ public class DefaultIndexReaderFactoryTest {
         LuceneIndexWriterFactory factory = newDirectoryFactory();
         enabledSuggestorForSomeProp();
         defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
 
         //Suggester field is only present for document in default mount
         Document doc = newDoc("/content/en");

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/MultiplexingIndexWriterTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/MultiplexingIndexWriterTest.java
@@ -80,14 +80,14 @@ public class MultiplexingIndexWriterTest {
     @Test
     public void defaultWriterWithNoMounts() throws Exception{
         LuceneIndexWriterFactory factory = newDirectoryFactory(Mounts.defaultMountInfoProvider());
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
         assertThat(writer, instanceOf(DefaultIndexWriter.class));
     }
 
     @Test
     public void closeWithoutChange() throws Exception{
         LuceneIndexWriterFactory factory = newDirectoryFactory();
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
         assertTrue(writer.close(0));
         assertEquals(2, Iterables.size(getIndexDirNodes()));
         assertFalse(builder.hasChildNode(indexDirName(roMount)));
@@ -95,10 +95,10 @@ public class MultiplexingIndexWriterTest {
         assertEquals(0, numDocs(defaultMount));
 
         // delete all dir nodes first
-        getIndexDirNodes().stream().forEach(dirName -> builder.getChildNode(dirName).remove());
+        getIndexDirNodes().forEach(dirName -> builder.getChildNode(dirName).remove());
 
         // empty index dir doesn't get created during normal indexing
-        writer = factory.newInstance(defn, builder, false);
+        writer = factory.newInstance(defn, builder, null, false);
         assertFalse(writer.close(0));
         assertEquals(0, Iterables.size(getIndexDirNodes()));
     }
@@ -106,7 +106,7 @@ public class MultiplexingIndexWriterTest {
     @Test
     public void writesInDefaultMount() throws Exception{
         LuceneIndexWriterFactory factory = newDirectoryFactory();
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
 
 
         //1. Add entry in foo mount
@@ -118,7 +118,7 @@ public class MultiplexingIndexWriterTest {
         assertEquals(0, numDocs(defaultMount));
 
         //2. Add entry in default mount
-        writer = factory.newInstance(defn, builder, true);
+        writer = factory.newInstance(defn, builder, null, true);
         writer.updateDocument("/content", newDoc("/content"));
         writer.close(0);
 
@@ -128,7 +128,7 @@ public class MultiplexingIndexWriterTest {
         assertEquals(1, numDocs(defaultMount));
 
         //3. Add another entry in foo mount without reindexing
-        writer = factory.newInstance(defn, builder, false);
+        writer = factory.newInstance(defn, builder, null, false);
         writer.updateDocument("/libs/config1", newDoc("/libs/config1"));
         writer.close(0);
 
@@ -137,7 +137,7 @@ public class MultiplexingIndexWriterTest {
         assertEquals(1, numDocs(defaultMount));
 
         //4. Add another entry in default mount without reindexing
-        writer = factory.newInstance(defn, builder, false);
+        writer = factory.newInstance(defn, builder, null, false);
         writer.updateDocument("/content1", newDoc("/content1"));
         writer.close(0);
 
@@ -155,7 +155,7 @@ public class MultiplexingIndexWriterTest {
 
         DirectoryFactory directoryFactory = new DefaultDirectoryFactory(null, new DataStoreBlobStore(ds));
         LuceneIndexWriterFactory factory = new DefaultIndexWriterFactory(mip, directoryFactory, writerConfig);
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
 
         //1. Add entry in foo mount
         writer.updateDocument("/libs/config", newDoc("/libs/config"));
@@ -166,7 +166,7 @@ public class MultiplexingIndexWriterTest {
         assertEquals(0, numDocs(defaultMount));
 
         //2. Add entry in default mount
-        writer = factory.newInstance(defn, builder, true);
+        writer = factory.newInstance(defn, builder, null, true);
         writer.updateDocument("/content", newDoc("/content"));
         writer.close(0);
 
@@ -176,7 +176,7 @@ public class MultiplexingIndexWriterTest {
         assertEquals(1, numDocs(defaultMount));
 
         //3. Add another entry in foo mount without reindexing
-        writer = factory.newInstance(defn, builder, false);
+        writer = factory.newInstance(defn, builder, null, false);
         writer.updateDocument("/libs/config1", newDoc("/libs/config1"));
         writer.close(0);
 
@@ -185,7 +185,7 @@ public class MultiplexingIndexWriterTest {
         assertEquals(1, numDocs(defaultMount));
 
         //4. Add another entry in default mount without reindexing
-        writer = factory.newInstance(defn, builder, false);
+        writer = factory.newInstance(defn, builder, null, false);
         writer.updateDocument("/content1", newDoc("/content1"));
         writer.close(0);
 
@@ -198,7 +198,7 @@ public class MultiplexingIndexWriterTest {
     @Test
     public void deletes() throws Exception{
         LuceneIndexWriterFactory factory = newDirectoryFactory();
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
 
         writer.updateDocument("/libs/config", newDoc("/libs/config"));
         writer.updateDocument("/libs/install", newDoc("/libs/install"));
@@ -209,14 +209,14 @@ public class MultiplexingIndexWriterTest {
         assertEquals(2, numDocs(fooMount));
         assertEquals(2, numDocs(defaultMount));
 
-        writer = factory.newInstance(defn, builder, true);
+        writer = factory.newInstance(defn, builder, null, true);
         writer.deleteDocuments("/libs/config");
         writer.close(0);
 
         assertEquals(1, numDocs(fooMount));
         assertEquals(2, numDocs(defaultMount));
 
-        writer = factory.newInstance(defn, builder, true);
+        writer = factory.newInstance(defn, builder, null, true);
         writer.deleteDocuments("/content");
         writer.close(0);
 
@@ -230,7 +230,7 @@ public class MultiplexingIndexWriterTest {
                 .mount("foo", "/content/remote").build();
         initializeMounts();
         LuceneIndexWriterFactory factory = newDirectoryFactory();
-        LuceneIndexWriter writer = factory.newInstance(defn, builder, true);
+        LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
 
         writer.updateDocument("/content/remote/a", newDoc("/content/remote/a"));
         writer.updateDocument("/etc", newDoc("/etc"));
@@ -240,7 +240,7 @@ public class MultiplexingIndexWriterTest {
         assertEquals(1, numDocs(fooMount));
         assertEquals(2, numDocs(defaultMount));
 
-        writer = factory.newInstance(defn, builder, true);
+        writer = factory.newInstance(defn, builder, null, true);
         writer.deleteDocuments("/content");
         writer.close(0);
 

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexerProvider.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexerProvider.java
@@ -33,7 +33,6 @@ import org.apache.jackrabbit.oak.plugins.index.lucene.writer.DefaultIndexWriterF
 import org.apache.jackrabbit.oak.plugins.index.lucene.writer.LuceneIndexWriter;
 import org.apache.jackrabbit.oak.plugins.index.progress.IndexingProgressReporter;
 import org.apache.jackrabbit.oak.plugins.index.search.ExtractedTextCache;
-import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.binary.FulltextBinaryTextExtractor;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
@@ -66,7 +65,7 @@ public class LuceneIndexerProvider implements NodeStateIndexerProvider {
 
         LuceneIndexDefinition idxDefinition = LuceneIndexDefinition.newBuilder(root, definition.getNodeState(), indexPath).reindex().build();
 
-        LuceneIndexWriter indexWriter = indexWriterFactory.newInstance(idxDefinition, definition, true);
+        LuceneIndexWriter indexWriter = indexWriterFactory.newInstance(idxDefinition, definition, null, true);
         FulltextBinaryTextExtractor textExtractor = new FulltextBinaryTextExtractor(textCache, idxDefinition, true);
         return new LuceneIndexer(
                 idxDefinition,

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
@@ -216,6 +216,7 @@ class ElasticBulkProcessorHandler {
                 int initialSize = failedDocSet.size();
                 boolean isFailedDocSetFull = false;
 
+                boolean hasSuccesses = false;
                 for (BulkItemResponse bulkItemResponse : bulkResponse) {
                     if (bulkItemResponse.isFailed()) {
                         BulkItemResponse.Failure failure = bulkItemResponse.getFailure();
@@ -227,9 +228,10 @@ class ElasticBulkProcessorHandler {
                         // Log entry to be used to parse logs to get the failed doc id/path if needed
                         LOG.error("ElasticIndex Update Doc Failure: Error while adding/updating doc with id : [{}]", bulkItemResponse.getId());
                         LOG.error("Failure Details: BulkItem ID: " + failure.getId() + ", Failure Cause: {}", failure.getCause());
-                    } else {
+                    } else if (!hasSuccesses) {
                         // Set indexUpdated to true even if 1 item was updated successfully
                         updatesMap.put(executionId, Boolean.TRUE);
+                        hasSuccesses = true;
                     }
                 }
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic.index;
+
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.bulk.BackoffPolicy;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+
+class ElasticBulkProcessorHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticBulkProcessorHandler.class);
+
+    private static final String SYNC_RT_MODE = "rt";
+
+    protected final ElasticConnection elasticConnection;
+    protected final ElasticIndexDefinition indexDefinition;
+    protected final BulkProcessor bulkProcessor;
+
+    /**
+     * Coordinates communication between bulk processes. It has a main controller registered at creation time and
+     * de-registered on {@link ElasticIndexWriter#close(long)}. Each bulk request register a new party in
+     * this Phaser in {@link OakBulkProcessorListener#beforeBulk(long, BulkRequest)} and de-register itself when
+     * the request returns.
+     */
+    private final Phaser phaser = new Phaser(1); // register main controller
+
+    /**
+     * Key-value structure to keep the history of bulk requests. Keys are the bulk execution ids, the boolean
+     * value is {@code true} when at least an update is performed, otherwise {@code false}.
+     */
+    private final ConcurrentHashMap<Long, Boolean> updatesMap = new ConcurrentHashMap<>();
+
+    protected final AtomicBoolean isClosed = new AtomicBoolean(false);
+
+    protected long totalOperations = 0;
+
+    private ElasticBulkProcessorHandler(@NotNull ElasticConnection elasticConnection,
+                                @NotNull ElasticIndexDefinition indexDefinition) {
+        this.elasticConnection = elasticConnection;
+        this.indexDefinition = indexDefinition;
+        this.bulkProcessor = initBulkProcessor();
+    }
+
+    /**
+     * Returns an ElasticBulkProcessorHandler instance based on the index definition configuration.
+     *
+     * The `sync-mode` property can be set to `rt` (real-time). In this case the returned handler will be real-time.
+     * This option is available for sync index definitions only.
+     */
+    public static ElasticBulkProcessorHandler getBulkProcessorHandler(@NotNull ElasticConnection elasticConnection,
+                                                                      @NotNull ElasticIndexDefinition indexDefinition) {
+        PropertyState async = indexDefinition.getDefinitionNodeState().getProperty("async");
+
+        if (async != null) {
+            return new ElasticBulkProcessorHandler(elasticConnection, indexDefinition);
+        }
+
+        PropertyState syncMode = indexDefinition.getDefinitionNodeState().getProperty("sync-mode");
+        if (syncMode != null && SYNC_RT_MODE.equals(syncMode.getValue(Type.STRING))) {
+            return new RealTimeBulkProcessorHandler(elasticConnection, indexDefinition);
+        }
+
+        return new ElasticBulkProcessorHandler(elasticConnection, indexDefinition);
+    }
+
+    private BulkProcessor initBulkProcessor() {
+        return BulkProcessor.builder(requestConsumer(),
+                new OakBulkProcessorListener())
+                .setBulkActions(indexDefinition.bulkActions)
+                .setBulkSize(new ByteSizeValue(indexDefinition.bulkSizeBytes))
+                .setFlushInterval(TimeValue.timeValueMillis(indexDefinition.bulkFlushIntervalMs))
+                .setBackoffPolicy(BackoffPolicy.exponentialBackoff(
+                        TimeValue.timeValueMillis(indexDefinition.bulkRetriesBackoff), indexDefinition.bulkRetries)
+                )
+                .build();
+    }
+
+    protected BiConsumer<BulkRequest, ActionListener<BulkResponse>> requestConsumer() {
+        return (request, bulkListener) -> elasticConnection.getClient().bulkAsync(request, RequestOptions.DEFAULT, bulkListener);
+    }
+
+    public void add(DocWriteRequest<?> request) {
+        bulkProcessor.add(request);
+        totalOperations++;
+    }
+
+    public boolean close() {
+        if (totalOperations <= 0) {
+            LOG.debug("No operations executed in this processor. Close immediately");
+            return false;
+        }
+        isClosed.set(true);
+        LOG.trace("Calling close on bulk processor {}", bulkProcessor);
+        bulkProcessor.close();
+        LOG.trace("Bulk Processor {} closed", bulkProcessor);
+
+        // de-register main controller
+        final int phase = phaser.arriveAndDeregister();
+
+        try {
+            phaser.awaitAdvanceInterruptibly(phase, indexDefinition.bulkFlushIntervalMs * 5, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | TimeoutException e) {
+            LOG.error("Error waiting for bulk requests to return", e);
+        }
+
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Bulk identifier -> update status = {}", updatesMap);
+        }
+        return updatesMap.containsValue(Boolean.TRUE);
+    }
+
+    private class OakBulkProcessorListener implements BulkProcessor.Listener {
+
+        @Override
+        public void beforeBulk(long executionId, BulkRequest bulkRequest) {
+            // register new bulk party
+            phaser.register();
+
+            // init update status
+            updatesMap.put(executionId, Boolean.FALSE);
+
+            LOG.debug("Sending bulk with id {} -> {}", executionId, bulkRequest.getDescription());
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Bulk Requests: \n{}", bulkRequest.requests()
+                        .stream()
+                        .map(DocWriteRequest::toString)
+                        .collect(Collectors.joining("\n"))
+                );
+            }
+        }
+
+        @Override
+        public void afterBulk(long executionId, BulkRequest bulkRequest, BulkResponse bulkResponse) {
+            LOG.debug("Bulk with id {} processed with status {} in {}", executionId, bulkResponse.status(), bulkResponse.getTook());
+            if (LOG.isTraceEnabled()) {
+                try {
+                    LOG.trace(Strings.toString(bulkResponse.toXContent(jsonBuilder(), EMPTY_PARAMS)));
+                } catch (IOException e) {
+                    LOG.error("Error decoding bulk response", e);
+                }
+            }
+            if (bulkResponse.hasFailures()) { // check if some operations failed to execute
+                for (BulkItemResponse bulkItemResponse : bulkResponse) {
+                    if (bulkItemResponse.isFailed()) {
+                        BulkItemResponse.Failure failure = bulkItemResponse.getFailure();
+                        LOG.error("Bulk item with id {} failed", failure.getId(), failure.getCause());
+                    } else {
+                        // Set indexUpdated to true even if 1 item was updated successfully
+                        updatesMap.put(executionId, Boolean.TRUE);
+                    }
+                }
+            } else {
+                updatesMap.put(executionId, Boolean.TRUE);
+            }
+            phaser.arriveAndDeregister();
+        }
+
+        @Override
+        public void afterBulk(long executionId, BulkRequest bulkRequest, Throwable throwable) {
+            LOG.error("Bulk with id {} threw an error", executionId, throwable);
+            phaser.arriveAndDeregister();
+        }
+    }
+
+    /**
+     * {@link ElasticBulkProcessorHandler} extension with real time behaviour.
+     * It also uses the same async bulk processor as the parent except for the last flush that waits until the
+     * indexed documents are searchable.
+     */
+    protected static class RealTimeBulkProcessorHandler extends ElasticBulkProcessorHandler {
+
+        private boolean isDataSearchable = false;
+
+        private RealTimeBulkProcessorHandler(@NotNull ElasticConnection elasticConnection, @NotNull ElasticIndexDefinition indexDefinition) {
+            super(elasticConnection, indexDefinition);
+        }
+
+        @Override
+        protected BiConsumer<BulkRequest, ActionListener<BulkResponse>> requestConsumer() {
+            return (request, bulkListener) -> {
+                if (isClosed.get()) {
+                    LOG.debug("Processor is closing. Next request with {} actions will block until the data is searchable",
+                            request.requests().size());
+                    request.setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
+                    isDataSearchable = true;
+                }
+                elasticConnection.getClient().bulkAsync(request, RequestOptions.DEFAULT, bulkListener);
+            };
+        }
+
+        @Override
+        public boolean close() {
+            boolean closed = super.close();
+            // it could happen that close gets called when the bulk has already been flushed. In these cases we trigger
+            // an actual refresh to make sure the docs are searchable before returning from the method
+            if (totalOperations > 0 && !isDataSearchable) {
+                LOG.debug("Forcing refresh");
+                try {
+                    this.elasticConnection.getClient()
+                            .indices()
+                            .refresh(new RefreshRequest(indexDefinition.getRemoteIndexAlias()), RequestOptions.DEFAULT);
+                } catch (IOException e) {
+                    LOG.warn("Error refreshing index " + indexDefinition.getRemoteIndexAlias(), e);
+                }
+            }
+            return closed;
+        }
+    }
+}

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
@@ -21,19 +21,11 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriter;
 import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
-import org.elasticsearch.action.bulk.BackoffPolicy;
-import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.bulk.BulkProcessor;
-import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.GetAliasesResponse;
 import org.elasticsearch.client.IndicesClient;
@@ -43,8 +35,6 @@ import org.elasticsearch.client.indices.CreateIndexResponse;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
@@ -52,14 +42,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Phaser;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -70,57 +54,22 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
     private final ElasticConnection elasticConnection;
     private final ElasticIndexDefinition indexDefinition;
 
-    /**
-     * Coordinates communication between bulk processes. It has a main controller registered at creation time and
-     * de-registered on {@link ElasticIndexWriter#close(long)}. Each bulk request register a new party in
-     * this Phaser in {@link OakBulkProcessorListener#beforeBulk(long, BulkRequest)} and de-register itself when
-     * the request returns.
-     */
-    private final Phaser phaser = new Phaser(1); // register main controller
-    /**
-     * Key-value structure to keep the history of bulk requests. Keys are the bulk execution ids, the boolean
-     * value is {@code true} when at least an update is performed, otherwise {@code false}.
-     */
-    private final ConcurrentHashMap<Long, Boolean> updatesMap = new ConcurrentHashMap<>();
-    private final AtomicBoolean isClosing = new AtomicBoolean(false);
-    private long totalOperations = 0;
-    private boolean isDataSearchable = false;
-    private final BulkProcessor bulkProcessor;
+    private final ElasticBulkProcessorHandler bulkProcessorHandler;
 
     ElasticIndexWriter(@NotNull ElasticConnection elasticConnection,
                        @NotNull ElasticIndexDefinition indexDefinition) {
         this.elasticConnection = elasticConnection;
         this.indexDefinition = indexDefinition;
-        bulkProcessor = initBulkProcessor();
+        this.bulkProcessorHandler = ElasticBulkProcessorHandler.getBulkProcessorHandler(elasticConnection, indexDefinition);
     }
 
     @TestOnly
     ElasticIndexWriter(@NotNull ElasticConnection elasticConnection,
                        @NotNull ElasticIndexDefinition indexDefinition,
-                       @NotNull BulkProcessor bulkProcessor) {
+                       @NotNull ElasticBulkProcessorHandler bulkProcessorHandler) {
         this.elasticConnection = elasticConnection;
         this.indexDefinition = indexDefinition;
-        this.bulkProcessor = bulkProcessor;
-    }
-
-    private BulkProcessor initBulkProcessor() {
-        return BulkProcessor.builder((request, bulkListener) -> {
-                    if (isClosing.get()) {
-                        LOG.debug("Processor is closing. Next request with {} actions will block until the data is searchable",
-                                request.requests().size());
-                        request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-                        isDataSearchable = true;
-                    }
-                    elasticConnection.getClient().bulkAsync(request, RequestOptions.DEFAULT, bulkListener);
-                },
-                new OakBulkProcessorListener())
-                .setBulkActions(indexDefinition.bulkActions)
-                .setBulkSize(new ByteSizeValue(indexDefinition.bulkSizeBytes))
-                .setFlushInterval(TimeValue.timeValueMillis(indexDefinition.bulkFlushIntervalMs))
-                .setBackoffPolicy(BackoffPolicy.exponentialBackoff(
-                        TimeValue.timeValueMillis(indexDefinition.bulkRetriesBackoff), indexDefinition.bulkRetries)
-                )
-                .build();
+        this.bulkProcessorHandler = bulkProcessorHandler;
     }
 
     @Override
@@ -128,53 +77,19 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
         IndexRequest request = new IndexRequest(indexDefinition.getRemoteIndexAlias())
                 .id(ElasticIndexUtils.idFromPath(path))
                 .source(doc.build(), XContentType.JSON);
-        bulkProcessor.add(request);
-        totalOperations++;
+        bulkProcessorHandler.add(request);
     }
 
     @Override
     public void deleteDocuments(String path) {
         DeleteRequest request = new DeleteRequest(indexDefinition.getRemoteIndexAlias())
                 .id(ElasticIndexUtils.idFromPath(path));
-        bulkProcessor.add(request);
-        totalOperations++;
+        bulkProcessorHandler.add(request);
     }
 
     @Override
     public boolean close(long timestamp) {
-        if (totalOperations <= 0) {
-            LOG.debug("No operations executed in this processor. Close immediately");
-            return false;
-        }
-        isClosing.set(true);
-        LOG.trace("Calling close on bulk processor {}", bulkProcessor);
-        bulkProcessor.close();
-        LOG.trace("Bulk Processor {} closed", bulkProcessor);
-
-        // de-register main controller
-        final int phase = phaser.arriveAndDeregister();
-
-        try {
-            phaser.awaitAdvanceInterruptibly(phase, indexDefinition.bulkFlushIntervalMs * 5, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException | TimeoutException e) {
-            LOG.error("Error waiting for bulk requests to return", e);
-        }
-
-        if (!isDataSearchable) {
-            LOG.debug("Forcing refresh");
-            try {
-                this.elasticConnection.getClient()
-                        .indices()
-                        .refresh(new RefreshRequest(indexDefinition.getRemoteIndexAlias()), RequestOptions.DEFAULT);
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-
-        if (LOG.isTraceEnabled()) {
-            LOG.trace("Bulk identifier -> update status = {}", updatesMap);
-        }
-        return updatesMap.containsValue(Boolean.TRUE);
+        return bulkProcessorHandler.close();
     }
 
     protected void provisionIndex() throws IOException {
@@ -250,59 +165,6 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
         AcknowledgedResponse deleteIndexResponse = indicesClient.delete(deleteIndexRequest, RequestOptions.DEFAULT);
         checkResponseAcknowledgement(deleteIndexResponse, "Delete index call not acknowledged for indices " + indices);
         LOG.info("Deleted indices {}. Response acknowledged: {}", indices.toString(), deleteIndexResponse.isAcknowledged());
-    }
-
-    private class OakBulkProcessorListener implements BulkProcessor.Listener {
-
-        @Override
-        public void beforeBulk(long executionId, BulkRequest bulkRequest) {
-            // register new bulk party
-            phaser.register();
-
-            // init update status
-            updatesMap.put(executionId, Boolean.FALSE);
-
-            LOG.debug("Sending bulk with id {} -> {}", executionId, bulkRequest.getDescription());
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Bulk Requests: \n{}", bulkRequest.requests()
-                        .stream()
-                        .map(DocWriteRequest::toString)
-                        .collect(Collectors.joining("\n"))
-                );
-            }
-        }
-
-        @Override
-        public void afterBulk(long executionId, BulkRequest bulkRequest, BulkResponse bulkResponse) {
-            LOG.debug("Bulk with id {} processed with status {} in {}", executionId, bulkResponse.status(), bulkResponse.getTook());
-            if (LOG.isTraceEnabled()) {
-                try {
-                    LOG.trace(Strings.toString(bulkResponse.toXContent(jsonBuilder(), EMPTY_PARAMS)));
-                } catch (IOException e) {
-                    LOG.error("Error decoding bulk response", e);
-                }
-            }
-            if (bulkResponse.hasFailures()) { // check if some operations failed to execute
-                for (BulkItemResponse bulkItemResponse : bulkResponse) {
-                    if (bulkItemResponse.isFailed()) {
-                        BulkItemResponse.Failure failure = bulkItemResponse.getFailure();
-                        LOG.error("Bulk item with id {} failed", failure.getId(), failure.getCause());
-                    } else {
-                        // Set indexUpdated to true even if 1 item was updated successfully
-                        updatesMap.put(executionId, Boolean.TRUE);
-                    }
-                }
-            } else {
-                updatesMap.put(executionId, Boolean.TRUE);
-            }
-            phaser.arriveAndDeregister();
-        }
-
-        @Override
-        public void afterBulk(long executionId, BulkRequest bulkRequest, Throwable throwable) {
-            LOG.error("Bulk with id {} threw an error", executionId, throwable);
-            phaser.arriveAndDeregister();
-        }
     }
 
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
@@ -20,6 +20,7 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriter;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
@@ -59,11 +60,12 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
 
     ElasticIndexWriter(@NotNull ElasticConnection elasticConnection,
                        @NotNull ElasticIndexDefinition indexDefinition,
-                       @NotNull NodeBuilder definitionBuilder) {
+                       @NotNull NodeBuilder definitionBuilder,
+                       CommitInfo commitInfo) {
         this.elasticConnection = elasticConnection;
         this.indexDefinition = indexDefinition;
         this.bulkProcessorHandler = ElasticBulkProcessorHandler
-                .getBulkProcessorHandler(elasticConnection, indexDefinition, definitionBuilder);
+                .getBulkProcessorHandler(elasticConnection, indexDefinition, definitionBuilder, commitInfo);
     }
 
     @TestOnly

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterFactory.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterFactory.java
@@ -38,6 +38,6 @@ class ElasticIndexWriterFactory implements FulltextIndexWriterFactory<ElasticDoc
             throw new IllegalArgumentException("IndexDefinition must be of type ElasticsearchIndexDefinition " +
                     "instead of " + definition.getClass().getName());
         }
-        return new ElasticIndexWriter(elasticConnection, (ElasticIndexDefinition) definition, definitionBuilder);
+        return new ElasticIndexWriter(elasticConnection, (ElasticIndexDefinition) definition, definitionBuilder, commitInfo);
     }
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterFactory.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterFactory.java
@@ -20,6 +20,7 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriterFactory;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.jetbrains.annotations.NotNull;
 
@@ -31,7 +32,8 @@ class ElasticIndexWriterFactory implements FulltextIndexWriterFactory<ElasticDoc
     }
 
     @Override
-    public ElasticIndexWriter newInstance(IndexDefinition definition, NodeBuilder definitionBuilder, boolean reindex) {
+    public ElasticIndexWriter newInstance(IndexDefinition definition, NodeBuilder definitionBuilder,
+                                          CommitInfo commitInfo, boolean reindex) {
         if (!(definition instanceof ElasticIndexDefinition)) {
             throw new IllegalArgumentException("IndexDefinition must be of type ElasticsearchIndexDefinition " +
                     "instead of " + definition.getClass().getName());

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFacetTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFacetTest.java
@@ -59,7 +59,6 @@ import java.util.stream.Collectors;
 import static org.apache.jackrabbit.commons.JcrUtils.getOrCreateByPath;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
-import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition.BULK_FLUSH_INTERVAL_MS_DEFAULT;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.FACETS;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_REFRESH_DEFN;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_SECURE_FACETS;
@@ -164,6 +163,7 @@ public class ElasticFacetTest {
         IndexSkeleton indexSkeleton = new IndexSkeleton();
         indexSkeleton.initialize();
         indexSkeleton.indexDefinitionBuilder.noAsync();
+        indexSkeleton.indexDefinitionBuilder.getBuilderTree().setProperty("sync-mode", "rt");
         indexSkeleton.indexRule.property("cons").propertyIndex();
         indexSkeleton.indexRule.property("foo").propertyIndex().getBuilderTree().setProperty(FACET_PROP, true, Type.BOOLEAN);
         indexSkeleton.indexRule.property("bar").propertyIndex().getBuilderTree().setProperty(FACET_PROP, true, Type.BOOLEAN);
@@ -226,7 +226,7 @@ public class ElasticFacetTest {
     @Test
     public void secureFacets() throws Exception {
         createDataset(NUM_LEAF_NODES_FOR_LARGE_DATASET);
-        assertEventually(() -> assertEquals(actualAclLabelCount, getFacets()));
+        assertEquals(actualAclLabelCount, getFacets());
     }
 
     @Test
@@ -236,7 +236,7 @@ public class ElasticFacetTest {
         inaccessibleChild.setProperty("cons", "val");
         inaccessibleChild.setProperty("foo", "l4");
         adminSession.save();
-        assertEventually(() -> assertEquals(actualAclLabelCount, getFacets()));
+        assertEquals(actualAclLabelCount, getFacets());
     }
 
     @Test
@@ -246,7 +246,7 @@ public class ElasticFacetTest {
         adminSession.save();
 
         createDataset(NUM_LEAF_NODES_FOR_LARGE_DATASET);
-        assertEventually(() -> assertEquals(actualLabelCount, getFacets()));
+        assertEquals(actualLabelCount, getFacets());
     }
 
     @Test
@@ -258,17 +258,15 @@ public class ElasticFacetTest {
 
         createDataset(NUM_LEAF_NODES_FOR_LARGE_DATASET);
 
-        assertEventually(() -> assertEquals("Unexpected number of facets", actualAclLabelCount.size(), getFacets().size()));
+        assertEquals("Unexpected number of facets", actualAclLabelCount.size(), getFacets().size());
 
         for (Map.Entry<String, Integer> facet : actualAclLabelCount.entrySet()) {
             String facetLabel = facet.getKey();
-            assertEventually(() -> {
-                int facetCount = getFacets().get(facetLabel);
-                float ratio = ((float) facetCount) / facet.getValue();
-                assertTrue("Facet count for label: " + facetLabel + " is outside of 10% margin of error. " +
-                                "Expected: " + facet.getValue() + "; Got: " + facetCount + "; Ratio: " + ratio,
-                        Math.abs(ratio - 1) < 0.1);
-            });
+            int facetCount = getFacets().get(facetLabel);
+            float ratio = ((float) facetCount) / facet.getValue();
+            assertTrue("Facet count for label: " + facetLabel + " is outside of 10% margin of error. " +
+                            "Expected: " + facet.getValue() + "; Got: " + facetCount + "; Ratio: " + ratio,
+                    Math.abs(ratio - 1) < 0.1);
         }
     }
 
@@ -281,11 +279,11 @@ public class ElasticFacetTest {
 
         createDataset(NUM_LEAF_NODES_FOR_SMALL_DATASET);
 
-        assertEventually(() -> assertEquals("Unexpected number of facets", actualAclLabelCount.size(), getFacets().size()));
+        assertEquals("Unexpected number of facets", actualAclLabelCount.size(), getFacets().size());
 
         // Since the hit count is less than sample size -> flow should have switched to secure facet count instead of statistical
         // and thus the count should be exactly equal
-        assertEventually(() -> assertEquals(actualAclLabelCount, getFacets()));
+        assertEquals(actualAclLabelCount, getFacets());
     }
 
     @Test
@@ -297,19 +295,17 @@ public class ElasticFacetTest {
 
         createDataset(NUM_LEAF_NODES_FOR_LARGE_DATASET);
 
-        assertEventually(() -> {
-            Map<String, Integer> facets = getFacets("/parent/par1");
-            assertEquals("Unexpected number of facets", actualAclPar1LabelCount.size(), facets.size());
+        Map<String, Integer> facets = getFacets("/parent/par1");
+        assertEquals("Unexpected number of facets", actualAclPar1LabelCount.size(), facets.size());
 
         for (Map.Entry<String, Integer> facet : actualAclPar1LabelCount.entrySet()) {
             String facetLabel = facet.getKey();
             int facetCount = facets.get(facetLabel);
             float ratio = ((float) facetCount) / facet.getValue();
             assertTrue("Facet count for label: " + facetLabel + " is outside of 10% margin of error. " +
-                                "Expected: " + facet.getValue() + "; Got: " + facetCount + "; Ratio: " + ratio,
-                        Math.abs(ratio - 1) < 0.1);
-            }
-        });
+                            "Expected: " + facet.getValue() + "; Got: " + facetCount + "; Ratio: " + ratio,
+                    Math.abs(ratio - 1) < 0.1);
+        }
     }
 
     @Test
@@ -324,21 +320,19 @@ public class ElasticFacetTest {
         inaccessibleChild.setProperty("cons", "val");
         inaccessibleChild.setProperty("foo", "l4");
         adminSession.save();
-        assertEventually(() -> {
-            Map<String, Integer> facets = getFacets();
-            assertEquals("Unexpected number of facets", actualAclLabelCount.size(), facets.size());
-        });
+
+        Map<String, Integer> facets = getFacets();
+        assertEquals("Unexpected number of facets", actualAclLabelCount.size(), facets.size());
 
         for (Map.Entry<String, Integer> facet : actualAclLabelCount.entrySet()) {
 
-            assertEventually(() -> {
-                String facetLabel = facet.getKey();
-                int facetCount = getFacets().get(facetLabel);
-                float ratio = ((float) facetCount) / facet.getValue();
-                assertTrue("Facet count for label: " + facetLabel + " is outside of 10% margin of error. " +
-                                "Expected: " + facet.getValue() + "; Got: " + facetCount + "; Ratio: " + ratio,
-                        Math.abs(ratio - 1) < 0.1);
-            });
+
+            String facetLabel = facet.getKey();
+            int facetCount = getFacets().get(facetLabel);
+            float ratio = ((float) facetCount) / facet.getValue();
+            assertTrue("Facet count for label: " + facetLabel + " is outside of 10% margin of error. " +
+                            "Expected: " + facet.getValue() + "; Got: " + facetCount + "; Ratio: " + ratio,
+                    Math.abs(ratio - 1) < 0.1);
         }
     }
 
@@ -350,7 +344,7 @@ public class ElasticFacetTest {
         adminSession.save();
         createDataset(NUM_LEAF_NODES_FOR_LARGE_DATASET);
         qe = adminSession.getWorkspace().getQueryManager();
-        assertEventually(() -> assertEquals(actualLabelCount, getFacets()));
+        assertEquals(actualLabelCount, getFacets());
     }
 
     @Test
@@ -361,20 +355,19 @@ public class ElasticFacetTest {
         adminSession.save();
         createDataset(NUM_LEAF_NODES_FOR_LARGE_DATASET);
         qe = adminSession.getWorkspace().getQueryManager();
-        assertEventually(() -> {
-            Map<String, Integer> facets = getFacets();
-            assertEquals("Unexpected number of facets", actualLabelCount.size(), facets.size());
-        });
+
+        Map<String, Integer> facets = getFacets();
+        assertEquals("Unexpected number of facets", actualLabelCount.size(), facets.size());
 
         for (Map.Entry<String, Integer> facet : actualLabelCount.entrySet()) {
-            assertEventually(() -> {
-                String facetLabel = facet.getKey();
-                int facetCount = getFacets().get(facetLabel);
-                float ratio = ((float) facetCount) / facet.getValue();
-                assertTrue("Facet count for label: " + facetLabel + " is outside of 5% margin of error. " +
-                                "Expected: " + facet.getValue() + "; Got: " + facetCount + "; Ratio: " + ratio,
-                        Math.abs(ratio - 1) < 0.05);
-            });
+
+            String facetLabel = facet.getKey();
+            int facetCount = getFacets().get(facetLabel);
+            float ratio = ((float) facetCount) / facet.getValue();
+            assertTrue("Facet count for label: " + facetLabel + " is outside of 5% margin of error. " +
+                            "Expected: " + facet.getValue() + "; Got: " + facetCount + "; Ratio: " + ratio,
+                    Math.abs(ratio - 1) < 0.05);
+
         }
     }
 
@@ -414,10 +407,6 @@ public class ElasticFacetTest {
                 .stream()
                 .flatMap(dim -> Objects.requireNonNull(facetResult.getFacets(dim)).stream())
                 .collect(Collectors.toMap(FacetResult.Facet::getLabel, FacetResult.Facet::getCount));
-    }
-
-    private static void assertEventually(Runnable r) {
-        ElasticTestUtils.assertEventually(r, BULK_FLUSH_INTERVAL_MS_DEFAULT * 3);
     }
 
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticOrderByTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticOrderByTest.java
@@ -33,11 +33,13 @@ public class ElasticOrderByTest extends ElasticAbstractQueryTest {
     @Test
     public void withoutOrderByClause() throws Exception {
         IndexDefinitionBuilder builder = createIndex("foo");
+        builder.getBuilderTree().setProperty("sync-mode", "rt");
         builder.indexRule("nt:base")
                 .property("foo")
                 .analyzed();
 
         setIndex(UUID.randomUUID().toString(), builder);
+        root.commit();
 
         Tree test = root.getTree("/").addChild("test");
         test.addChild("a").setProperty("foo", "hello");
@@ -45,13 +47,13 @@ public class ElasticOrderByTest extends ElasticAbstractQueryTest {
         root.commit();
 
         // results are sorted by score desc, node `b` returns first because it has a higher score from a tf/idf perspective
-        assertEventually(() -> assertOrderedQuery("select [jcr:path] from [nt:base] where contains(foo, 'hello')",
-                asList("/test/b", "/test/a")));
+        assertOrderedQuery("select [jcr:path] from [nt:base] where contains(foo, 'hello')", asList("/test/b", "/test/a"));
     }
 
     @Test
     public void orderByScore() throws Exception {
         IndexDefinitionBuilder builder = createIndex("foo");
+        builder.getBuilderTree().setProperty("sync-mode", "rt");
         builder.indexRule("nt:base")
                 .property("foo")
                 .analyzed();
@@ -63,18 +65,17 @@ public class ElasticOrderByTest extends ElasticAbstractQueryTest {
         test.addChild("b").setProperty("foo", "hello hello");
         root.commit();
 
-        assertEventually(() -> {
-            assertOrderedQuery("select [jcr:path] from [nt:base] where contains(foo, 'hello') order by [jcr:score]",
-                    asList("/test/a", "/test/b"));
+        assertOrderedQuery("select [jcr:path] from [nt:base] where contains(foo, 'hello') order by [jcr:score]",
+                asList("/test/a", "/test/b"));
 
-            assertOrderedQuery("select [jcr:path] from [nt:base] where contains(foo, 'hello') order by [jcr:score] DESC",
-                    asList("/test/b", "/test/a"));
-        });
+        assertOrderedQuery("select [jcr:path] from [nt:base] where contains(foo, 'hello') order by [jcr:score] DESC",
+                asList("/test/b", "/test/a"));
     }
 
     @Test
     public void orderByPath() throws Exception {
         IndexDefinitionBuilder builder = createIndex("foo");
+        builder.getBuilderTree().setProperty("sync-mode", "rt");
         builder.indexRule("nt:base").property("foo");
 
         setIndex(UUID.randomUUID().toString(), builder);
@@ -84,16 +85,14 @@ public class ElasticOrderByTest extends ElasticAbstractQueryTest {
         test.addChild("b").setProperty("foo", "bbbbbb");
         root.commit();
 
-        assertEventually(() -> {
-            assertOrderedQuery("select [jcr:path] from [nt:base] order by [jcr:path]", asList("/test/a", "/test/b"));
-
-            assertOrderedQuery("select [jcr:path] from [nt:base] order by [jcr:path] DESC", asList("/test/b", "/test/a"));
-        });
+        assertOrderedQuery("select [jcr:path] from [nt:base] order by [jcr:path]", asList("/test/a", "/test/b"));
+        assertOrderedQuery("select [jcr:path] from [nt:base] order by [jcr:path] DESC", asList("/test/b", "/test/a"));
     }
 
     @Test
     public void orderByProperty() throws Exception {
         IndexDefinitionBuilder builder = createIndex("foo");
+        builder.getBuilderTree().setProperty("sync-mode", "rt");
         builder.indexRule("nt:base").property("foo");
 
         setIndex(UUID.randomUUID().toString(), builder);
@@ -103,16 +102,15 @@ public class ElasticOrderByTest extends ElasticAbstractQueryTest {
         test.addChild("b").setProperty("foo", "aaaaaa");
         root.commit();
 
-        assertEventually(() -> {
-            assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo", asList("/test/b", "/test/a"));
 
-            assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo DESC", asList("/test/a", "/test/b"));
-        });
+        assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo", asList("/test/b", "/test/a"));
+        assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo DESC", asList("/test/a", "/test/b"));
     }
 
     @Test
     public void orderByAnalyzedProperty() throws Exception {
         IndexDefinitionBuilder builder = createIndex("foo");
+        builder.getBuilderTree().setProperty("sync-mode", "rt");
         builder.indexRule("nt:base").property("foo").analyzed();
 
         setIndex(UUID.randomUUID().toString(), builder);
@@ -125,16 +123,14 @@ public class ElasticOrderByTest extends ElasticAbstractQueryTest {
         // this test verifies we use the keyword multi field when an analyzed properties is specified in order by
         // http://www.technocratsid.com/string-sorting-in-elasticsearch/
 
-        assertEventually(() -> {
-            assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo", asList("/test/a", "/test/b"));
-
-            assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo DESC", asList("/test/b", "/test/a"));
-        });
+        assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo", asList("/test/a", "/test/b"));
+        assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo DESC", asList("/test/b", "/test/a"));
     }
 
     @Test
     public void orderByNumericProperty() throws Exception {
         IndexDefinitionBuilder builder = createIndex("foo");
+        builder.getBuilderTree().setProperty("sync-mode", "rt");
         builder.indexRule("nt:base").property("foo").type(PropertyType.TYPENAME_LONG);
 
         setIndex(UUID.randomUUID().toString(), builder);
@@ -144,16 +140,14 @@ public class ElasticOrderByTest extends ElasticAbstractQueryTest {
         test.addChild("b").setProperty("foo", "5");
         root.commit();
 
-        assertEventually(() -> {
-            assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo", asList("/test/b", "/test/a"));
-
-            assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo DESC", asList("/test/a", "/test/b"));
-        });
+        assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo", asList("/test/b", "/test/a"));
+        assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo DESC", asList("/test/a", "/test/b"));
     }
 
     @Test
     public void orderByMultiProperties() throws Exception {
         IndexDefinitionBuilder builder = createIndex("foo", "bar");
+        builder.getBuilderTree().setProperty("sync-mode", "rt");
         builder.indexRule("nt:base").property("foo");
         builder.indexRule("nt:base").property("bar").type(PropertyType.TYPENAME_LONG);
 
@@ -171,16 +165,14 @@ public class ElasticOrderByTest extends ElasticAbstractQueryTest {
         b.setProperty("bar", "100");
         root.commit();
 
-        assertEventually(() -> {
-            assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo, @bar",
-                    asList("/test/a1", "/test/a2", "/test/b"));
+        assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo, @bar",
+                asList("/test/a1", "/test/a2", "/test/b"));
 
-            assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo, @bar DESC",
-                    asList("/test/a2", "/test/a1", "/test/b"));
+        assertOrderedQuery("select [jcr:path] from [nt:base] order by @foo, @bar DESC",
+                asList("/test/a2", "/test/a1", "/test/b"));
 
-            assertOrderedQuery("select [jcr:path] from [nt:base] order by @bar DESC, @foo DESC",
-                    asList("/test/b", "/test/a2", "/test/a1"));
-        });
+        assertOrderedQuery("select [jcr:path] from [nt:base] order by @bar DESC, @foo DESC",
+                asList("/test/b", "/test/a2", "/test/a1"));
     }
 
     private void assertOrderedQuery(String sql, List<String> paths) {

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandlerTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandlerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic.index;
+
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
+import org.apache.jackrabbit.oak.plugins.memory.MultiStringPropertyState;
+import org.apache.jackrabbit.oak.plugins.memory.StringPropertyState;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
+public class ElasticBulkProcessorHandlerTest {
+
+    @Mock
+    private ElasticIndexDefinition indexDefinitionMock;
+
+    @Mock
+    private NodeState definitionNodeStateMock;
+
+    @Mock
+    private ElasticConnection elasticConnectionMock;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(indexDefinitionMock.getDefinitionNodeState()).thenReturn(definitionNodeStateMock);
+    }
+
+    @Test
+    public void defaultMode() {
+        when(definitionNodeStateMock.getProperty(eq("async"))).thenReturn(null);
+
+        ElasticBulkProcessorHandler bulkProcessorHandler =
+                ElasticBulkProcessorHandler.getBulkProcessorHandler(elasticConnectionMock, indexDefinitionMock);
+
+        assertThat(bulkProcessorHandler, instanceOf(ElasticBulkProcessorHandler.class));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void multiSyncModes() {
+        when(definitionNodeStateMock.getProperty(eq("async"))).thenReturn(null);
+        when(definitionNodeStateMock.getProperty(eq("sync-mode")))
+                .thenReturn(new MultiStringPropertyState("sync-mode", Arrays.asList("nrt", "rt")));
+
+        ElasticBulkProcessorHandler.getBulkProcessorHandler(elasticConnectionMock, indexDefinitionMock);
+    }
+
+    @Test
+    public void rtMode() {
+        when(definitionNodeStateMock.getProperty(eq("async"))).thenReturn(null);
+        when(definitionNodeStateMock.getProperty(eq("sync-mode")))
+                .thenReturn(new StringPropertyState("sync-mode", "rt"));
+
+        ElasticBulkProcessorHandler bulkProcessorHandler =
+                ElasticBulkProcessorHandler.getBulkProcessorHandler(elasticConnectionMock, indexDefinitionMock);
+
+        assertThat(bulkProcessorHandler, instanceOf(ElasticBulkProcessorHandler.RealTimeBulkProcessorHandler.class));
+    }
+}

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditorContext.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditorContext.java
@@ -48,9 +48,7 @@ import org.slf4j.LoggerFactory;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_RANDOM_SEED;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_REFRESH_DEFN;
-import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.REGEX_ALL_PROPS;
 import static org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition.INDEX_DEFINITION_NODE;
-import static org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition.REINDEX_COMPLETION_TIMESTAMP;
 import static org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition.STATUS_NODE;
 
 /**
@@ -99,7 +97,7 @@ public abstract class FulltextIndexEditorContext<D> {
   protected FulltextIndexEditorContext(NodeState root, NodeBuilder definition,
                                        @Nullable IndexDefinition indexDefinition,
                                        IndexUpdateCallback updateCallback,
-                                       FulltextIndexWriterFactory indexWriterFactory,
+                                       FulltextIndexWriterFactory<D> indexWriterFactory,
                                        ExtractedTextCache extractedTextCache,
                                        IndexingContext indexingContext, boolean asyncIndexing) {
     this.root = root;
@@ -133,7 +131,7 @@ public abstract class FulltextIndexEditorContext<D> {
     if (writer == null) {
       //Lazy initialization so as to ensure that definition is based
       //on latest NodeBuilder state specially in case of reindexing
-      writer = indexWriterFactory.newInstance(definition, definitionBuilder, reindex);
+      writer = indexWriterFactory.newInstance(definition, definitionBuilder, indexingContext.getCommitInfo(), reindex);
     }
     return writer;
   }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexWriterFactory.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexWriterFactory.java
@@ -20,6 +20,7 @@
 package org.apache.jackrabbit.oak.plugins.index.search.spi.editor;
 
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 
 /**
@@ -31,9 +32,11 @@ public interface FulltextIndexWriterFactory<D> {
      * create a new index writer instance
      * @param definition the index definition
      * @param definitionBuilder the node builder associated with the index definition
+     * @param commitInfo metadata associated with the commit for this writer
      * @param reindex whether or not reindex should be performed
      * @return an index writer
      */
-    FulltextIndexWriter<D> newInstance(IndexDefinition definition, NodeBuilder definitionBuilder, boolean reindex);
+    FulltextIndexWriter<D> newInstance(IndexDefinition definition, NodeBuilder definitionBuilder,
+                                       CommitInfo commitInfo, boolean reindex);
 
 }


### PR DESCRIPTION
This PR introduces a new `sync-mode` property that can be used with `sync` indexes only.

By default, a `sync` index gets updated in near-real-time (~ 1s). With `sync-mode=rt` we can make sure the saved data is immediately available for search when the commit call returns. This mode should work quite well when the user does bulk commits because only the last request to ES requires the data to be searchable.

As an example: if we create/modify 2500 nodes that need to be indexed, the IndexWriter will make 10 requests to ES but only the last one will be blocked until the data is searchable.

On the other side, a client that commits frequently can experience slow index performance.

The sync-mode can be specified also for specific commits in the commit-info metadata. With this option, we can have a traditional NRT index that performs fairly well in the majority of operations and we can decide to have specific commits with rt behavior in this way

```java
root.commit(Collections.singletonMap("sync-mode", "rt"));
```

I have also changed some tests to use the RT sync-mode. `assertEventually` is not needed anymore.