### PR TITLE
OAK-9155: avoid duplication of analyzed/nodeScopeIndex values in :fulltext

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMaker.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMaker.java
@@ -110,8 +110,12 @@ class ElasticDocumentMaker extends FulltextDocumentMaker<ElasticDocument> {
 
     @Override
     protected void indexFulltextValue(ElasticDocument doc, String value) {
-        // Note: diversion from lucene impl - here we are storing even these cases and not just binary
         doc.addFulltext(value);
+    }
+
+    @Override
+    protected boolean isFulltextValuePersisted() {
+        return false;
     }
 
     @Override

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -130,7 +130,6 @@ class ElasticIndexHelper {
                 .field("type", "integer")
                 .field("doc_values", false) // no need to sort/aggregate here
                 .endObject();
-        // TODO: to increase efficiency, we could potentially remove this and use a multi match query when needed
         mappingBuilder.startObject(FieldNames.FULLTEXT)
                 .field("type", "text")
                 .field("analyzer", "oak_analyzer")

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexAggregationNtFileTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexAggregationNtFileTest.java
@@ -126,7 +126,7 @@ public class ElasticIndexAggregationNtFileTest extends ElasticAbstractQueryTest 
     }
 
     @Test
-    public void indexNtFileText() throws CommitFailedException, InterruptedException {
+    public void indexNtFileText() throws CommitFailedException {
         setTraversalEnabled(false);
         final String statement = "//element(*, test:Asset)[ " +
                 "jcr:contains(jcr:content/renditions/dam.text.txt/jcr:content, 'quick') ]";

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -277,7 +277,9 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
                     }
 
                     if (pd.nodeScopeIndex) {
-                        indexFulltextValue(doc, value);
+                        if (isFulltextValuePersisted()) {
+                            indexFulltextValue(doc, value);
+                        }
                         if (pd.useInSimilarity) {
                             log.trace("indexing similarity strings for {}", pd.name);
                             try {
@@ -301,6 +303,13 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
         }
 
         return dirty;
+    }
+
+    /**
+     * Returns {@code true} if nodeScopeIndex full text values need to be indexed
+     */
+    protected boolean isFulltextValuePersisted() {
+        return true;
     }
 
     protected abstract boolean indexSimilarityTag(D doc, PropertyState property);


### PR DESCRIPTION
The initial intent of this PR was to completely get rid of `:fulltext` field.

This is not just used for analyzed/nodeScopeIndex fields though but also for other features (renditions, spellcheck).

The field is still part of the mapping but it's not used to store analyzed/nodeScopeIndex properties. The query side uses a multi-match cross-fields query. This improves both indexing and query performance.