### PR TITLE
OAK-9165 Lucene: unique sync property index don't work properly

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/strategy/UniqueEntryStoreStrategy.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/strategy/UniqueEntryStoreStrategy.java
@@ -89,7 +89,7 @@ public class UniqueEntryStoreStrategy implements IndexStoreStrategy {
             // there could be (temporarily) multiple entries
             // we need to remove the right one
             PropertyState s = builder.getProperty("entry");
-            if (s.count() == 1) {
+            if (s == null || s.count() == 1) {
                 builder.remove();
             } else {
                 ArrayList<String> list = new ArrayList<String>();


### PR DESCRIPTION
I didn't manage to create a test case to reproduce the issue unfortunately. However I think this change in any case improves stability and fixes the issue I have seen on my test.