### PR TITLE
OAK-9194: propertyIndex with nodeScopeIndex should be stored in :fulltext only

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -136,7 +136,7 @@ public class ElasticIndexDefinition extends IndexDefinition {
     }
 
     public boolean isAnalyzed(List<PropertyDefinition> propertyDefinitions) {
-        return propertyDefinitions.stream().anyMatch(pd -> pd.analyzed || pd.fulltextEnabled());
+        return propertyDefinitions.stream().anyMatch(pd -> pd.analyzed);
     }
 
     @Override


### PR DESCRIPTION
more context here https://issues.apache.org/jira/browse/OAK-9194