### PR TITLE
OAK-9375: Remote elastic index deletion job incorrectly deletes indices

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexCleaner.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexCleaner.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
@@ -89,6 +90,7 @@ public class ElasticIndexCleaner implements Runnable {
                     filter(index -> Arrays.stream(remoteIndices).noneMatch(remoteIndex -> remoteIndex.equals(index))).collect(Collectors.toList());
             externallyDeletedIndices.forEach(danglingRemoteIndicesMap::remove);
             Set<String> existingIndices = new HashSet<>();
+            AtomicBoolean shouldReturnSilently = new AtomicBoolean(false);
             root.getChildNode(INDEX_DEFINITIONS_NAME).getChildNodeEntries().forEach(childNodeEntry -> {
                 PropertyState typeProperty = childNodeEntry.getNodeState().getProperty(IndexConstants.TYPE_PROPERTY_NAME);
                 String typeValue = typeProperty != null ? typeProperty.getValue(Type.STRING) : "";
@@ -101,10 +103,26 @@ public class ElasticIndexCleaner implements Runnable {
                     String remoteIndexName = ElasticIndexNameHelper.getRemoteIndexName(indexPrefix, childNodeEntry.getNodeState(), indexPath);
                     if (remoteIndexName != null) {
                         existingIndices.add(remoteIndexName);
+                    } else if (typeValue.equals(ElasticIndexDefinition.TYPE_ELASTICSEARCH)){
+                        /*
+                            Didn't check for disabled indexes in this "else if" condition because an index could be disabled at three stages
+                            and the following should hold -
+                            Stage 1 - index definition was created with type="disabled". This means indexing has not been done for index and
+                            hence remote index name and the remote index itself shouldn't exist
+                            Stage 2 - index was disabled after indexing was complete - in this case we would find remote index name and won't
+                            enter this condition
+                            Stage 3 - index was disabled after indexing started but before it was complete. Ideally this should only be done in
+                            case of some error in indexing and after interrupting and pausing indexing lane. So in this case it should be safe to
+                            delete the partially created remote index as it should be recreated by reindexing.
+                         */
+                        LOG.info("Could not obtain remote index name for {}. Won't delete any index.", childNodeEntry.getName());
+                        shouldReturnSilently.set(true);
                     }
                 }
             });
-
+            if (shouldReturnSilently.get()) {
+                return;
+            }
             List<String> indicesToDelete = new ArrayList<>();
             for (String remoteIndexName : remoteIndices) {
                 if (!existingIndices.contains(remoteIndexName)) {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexCleaner.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexCleaner.java
@@ -98,12 +98,12 @@ public class ElasticIndexCleaner implements Runnable {
                 If index type is "elasticsearch" or "disabled", we try to find remote index name. In case of disabled lucene or
                 property indices, the remote index name would be null. So only elasticsearch indices are affected here.
                  */
-                if (typeValue.equals(ElasticIndexDefinition.TYPE_ELASTICSEARCH) || typeValue.equals("disabled")) {
+                if (ElasticIndexDefinition.TYPE_ELASTICSEARCH.equals(typeValue) || "disabled".equals(typeValue)) {
                     String indexPath = "/" + INDEX_DEFINITIONS_NAME + "/" + childNodeEntry.getName();
                     String remoteIndexName = ElasticIndexNameHelper.getRemoteIndexName(indexPrefix, childNodeEntry.getNodeState(), indexPath);
                     if (remoteIndexName != null) {
                         existingIndices.add(remoteIndexName);
-                    } else if (typeValue.equals(ElasticIndexDefinition.TYPE_ELASTICSEARCH)){
+                    } else if (ElasticIndexDefinition.TYPE_ELASTICSEARCH.equals(typeValue)){
                         /*
                             Didn't check for disabled indexes in this "else if" condition because an index could be disabled at three stages
                             and the following should hold -

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexNameHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexNameHelper.java
@@ -23,6 +23,8 @@ import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -32,6 +34,8 @@ import java.util.stream.StreamSupport;
 import static org.elasticsearch.common.Strings.INVALID_FILENAME_CHARS;
 
 public class ElasticIndexNameHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticIndexNameHelper.class);
 
     private static final int MAX_NAME_LENGTH = 255;
 
@@ -57,6 +61,7 @@ public class ElasticIndexNameHelper {
         }
         PropertyState seedProp = indexNode.getProperty(ElasticIndexDefinition.PROP_INDEX_NAME_SEED);
         if (seedProp == null) {
+            LOG.debug("Could not obtain remote index name. No seed found for index {}", indexPath);
             return null;
         }
         long seed = seedProp.getValue(Type.LONG);

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
@@ -110,11 +110,13 @@ public class ElasticIndexProviderService {
                 description = "Local file system path where text extraction cache stores/load entries to recover from timed out operation")
         String localTextExtractionDir();
 
-        @AttributeDefinition(name = "Remote index cleanup frequency", description = "Frequency (in seconds) of running remote index deletion scheduled task. Set this to -1 to disable the task.")
+        @AttributeDefinition(name = "Remote index cleanup frequency", description = "Frequency (in seconds) of running remote index deletion scheduled task." +
+                "Set this to -1 to disable the task. Default is 1 minute.")
         int remoteIndexCleanupFrequency() default 60;
 
-        @AttributeDefinition(name = "Remote index deletion threshold", description = "Time in seconds after which a remote index whose local index is not found gets deleted")
-        int remoteIndexDeletionThreshold() default 86400;
+        @AttributeDefinition(name = "Remote index deletion threshold", description = "Time in seconds after which a remote index whose local index is not found gets deleted." +
+                "Default is 1 day.")
+        int remoteIndexDeletionThreshold() default 24*60*60;
     }
 
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
@@ -110,11 +110,11 @@ public class ElasticIndexProviderService {
                 description = "Local file system path where text extraction cache stores/load entries to recover from timed out operation")
         String localTextExtractionDir();
 
-        @AttributeDefinition(name = "Remote index cleanup frequency", description = "Frequency (in seconds) of running remote index deletion scheduled task")
+        @AttributeDefinition(name = "Remote index cleanup frequency", description = "Frequency (in seconds) of running remote index deletion scheduled task. Set this to -1 to disable the task.")
         int remoteIndexCleanupFrequency() default 60;
 
         @AttributeDefinition(name = "Remote index deletion threshold", description = "Time in seconds after which a remote index whose local index is not found gets deleted")
-        int remoteIndexDeletionThreshold() default 300;
+        int remoteIndexDeletionThreshold() default 86400;
     }
 
 
@@ -183,6 +183,9 @@ public class ElasticIndexProviderService {
         boolean reachable = elasticConnection.isAvailable();
         if (!reachable) {
             throw new IllegalArgumentException("Elastic server is not available - " + elasticConnection.toString());
+        }
+        if (contextConfig.remoteIndexCleanupFrequency() == -1) {
+            return;
         }
         ElasticIndexCleaner task = new ElasticIndexCleaner(elasticConnection, nodeStore, contextConfig.remoteIndexDeletionThreshold());
         oakRegs.add(scheduleWithFixedDelay(whiteboard, task, contextConfig.remoteIndexCleanupFrequency()));

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
@@ -111,8 +111,8 @@ public class ElasticIndexProviderService {
         String localTextExtractionDir();
 
         @AttributeDefinition(name = "Remote index cleanup frequency", description = "Frequency (in seconds) of running remote index deletion scheduled task." +
-                "Set this to -1 to disable the task. Default is 1 minute.")
-        int remoteIndexCleanupFrequency() default 60;
+                "Set this to -1 to disable the task. Default is 1 hour.")
+        int remoteIndexCleanupFrequency() default 60*60;
 
         @AttributeDefinition(name = "Remote index deletion threshold", description = "Time in seconds after which a remote index whose local index is not found gets deleted." +
                 "Default is 1 day.")


### PR DESCRIPTION
* Don't delete index if seed is not found
* Option to disable the deletion task
* Increase deletion threshold