### PR TITLE
GRANITE-34058: use dynamic boost in must query

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -569,10 +569,11 @@ public class ElasticRequestHandler {
                 if (boost != null) {
                     fullTextQuery.boost(Float.parseFloat(boost));
                 }
-                BoolQueryBuilder boolQueryBuilder = boolQuery().must(fullTextQuery);
-                // add dynamic boosts in SHOULD if available
+                BoolQueryBuilder shouldBoolQueryWrapper = boolQuery().should(fullTextQuery);
+                // add dynamic boosts in OR if available
                 Stream<QueryBuilder> dynamicScoreQueries = dynamicScoreQueries(text);
-                dynamicScoreQueries.forEach(boolQueryBuilder::should);
+                dynamicScoreQueries.forEach(shouldBoolQueryWrapper::should);
+                BoolQueryBuilder boolQueryBuilder = boolQuery().must(shouldBoolQueryWrapper);
 
                 if (not) {
                     BoolQueryBuilder bq = boolQuery().mustNot(boolQueryBuilder);


### PR DESCRIPTION
Dynamic tags were used just to rescore matched results. They should instead be used to match the input and then rescore.